### PR TITLE
Fixed minor glitches in js counter example

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -1,4 +1,3 @@
-var wire = require("js-wire");
 var tmsp = require("js-tmsp");
 var util = require("util");
 

--- a/example/app.js
+++ b/example/app.js
@@ -55,7 +55,6 @@ CounterApp.prototype.checkTx = function(req, cb) {
       return cb({code:tmsp.CodeType.BadNonce, log:"Nonce is too low. Got "+txValue+", expected >= "+this.txCount});
 		}
 	}
-	this.txCount += 1;
 	return cb({code:tmsp.CodeType_OK});
 }
 

--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,6 @@
   "description": "Javascript TMSP example application",
   "main": "app.js",
   "dependencies": {
-    "js-tmsp": "0.0.1"
+    "js-tmsp": "0.0.9"
   }
 }
-


### PR DESCRIPTION
Without these fixes, the js counter example would not run straight off the bat as per the tutorial documentation. The glitches fixed look like they got here due to a bit of drift from previous js-tmsp versions.
