### PR TITLE
fix errors in example counter app

### DIFF
--- a/example/app.js
+++ b/example/app.js
@@ -26,7 +26,7 @@ CounterApp.prototype.setOption = function(req, cb) {
 }
 
 CounterApp.prototype.appendTx = function(req, cb) {
-  var txBytes = req.data.toBuffer();
+  var txBytes = req.append_tx.tx.buffer;
 	if (this.serial) {
 		if (txBytes.length >= 2 && txBytes.slice(0, 2) == "0x") {
       var hexString = txBytes.toString("ascii", 2);
@@ -43,7 +43,7 @@ CounterApp.prototype.appendTx = function(req, cb) {
 }
 
 CounterApp.prototype.checkTx = function(req, cb) {
-  var txBytes = req.data.toBuffer();
+  var txBytes = req.check_tx.tx.buffer;
 	if (this.serial) {
 		if (txBytes.length >= 2 && txBytes.slice(0, 2) == "0x") {
       var hexString = txBytes.toString("ascii", 2);


### PR DESCRIPTION
This pool request fix error when js-tmsp appcliation send append_tx or check_tx commands:
```
Counter app in Javascript
new connection from ::ffff:127.0.0.1:33988
FATAL ERROR STACK:  TypeError: Cannot read property 'toBuffer' of undefined
    at CounterApp.appendTx (/home/ubuntu/workspace/js-tmsp/example/app.js:29:25)
    at Connection.msgCb (/home/ubuntu/workspace/node_modules/js-tmsp/server.js:70:34)
    at Connection.appendData (/home/ubuntu/workspace/node_modules/js-tmsp/connection.js:41:10)
    at Socket.<anonymous> (/home/ubuntu/workspace/node_modules/js-tmsp/connection.js:15:10)
    at emitOne (events.js:77:13)
    at Socket.emit (events.js:169:7)
    at readableAddChunk (_stream_readable.js:153:18)
    at Socket.Readable.push (_stream_readable.js:111:10)
    at TCP.onread (net.js:536:20)
FATAL ERROR:  [TypeError: Cannot read property 'toBuffer' of undefined]
```