### PR TITLE
Rename the name value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "abci",
+  "name": "js-abci",
   "version": "4.0.2",
   "description": "Tendermint ABCI server",
   "main": "index.js",


### PR DESCRIPTION
As it currently is if I run `npm install abci` then I get an error: `npm ERR! Refusing to install abci as a dependency of itself`. This fixes it.