### PR TITLE
Update connection.js

### DIFF
--- a/src/connection.js
+++ b/src/connection.js
@@ -66,7 +66,7 @@ class Connection extends EventEmitter {
       this.waiting = false
       this.stream.resume()
 
-      if (this.recvBuf.length > 0) {
+      if (this.recvBuf.length >= 3) { 
         this.maybeReadNextMessage()
       }
     })


### PR DESCRIPTION
Fix Varint decode failing, if buffer empty (1 byte length). Minimal valid command length = 3