### PR TITLE
Handle client connection errors

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -56,7 +56,7 @@ function createServer (app) {
         fail(err)
       }
     })
-    conn.on('error', err => { });
+    conn.on('error', err => {})
   })
 
   return server

--- a/src/server.js
+++ b/src/server.js
@@ -56,7 +56,7 @@ function createServer (app) {
         fail(err)
       }
     })
-    conn.on('error', () => {/* by this point the conn.stream is destroyed, nothing else to do !!*/})
+    conn.on('error', () => { /* by this point the conn.stream is destroyed, nothing else to do !! */ })
   })
 
   return server

--- a/src/server.js
+++ b/src/server.js
@@ -56,6 +56,7 @@ function createServer (app) {
         fail(err)
       }
     })
+    conn.on('error', err => { });
   })
 
   return server

--- a/src/server.js
+++ b/src/server.js
@@ -56,7 +56,7 @@ function createServer (app) {
         fail(err)
       }
     })
-    conn.on('error', err => {})
+    conn.on('error', () => {/* by this point the conn.stream is destroyed, nothing else to do !!*/})
   })
 
   return server


### PR DESCRIPTION
When the Tendermint server is killed / crashed, it is crashing the ABCI proxy app, due to  the connection error event. This fixes the issue.