### PR TITLE
Change the app name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "abci",
+  "name": "js-abci",
   "version": "7.0.0",
   "description": "Tendermint ABCI server",
   "main": "index.js",


### PR DESCRIPTION
This changes the app name in package.json from 'abci' to 'js-abci' because 'npm install abci' throws the following error: 
"npm ERR! code ENOSELF
npm ERR! Refusing to install package with name "abci" under a package
npm ERR! also called "abci". Did you name your project the same
npm ERR! as the dependency you're installing?
npm ERR! 
npm ERR! For more information, see:
npm ERR!     <https://docs.npmjs.com/cli/install#limitations-of-npms-install-algorithm>"